### PR TITLE
Moved the errors under the Yelp::Error namespace

### DIFF
--- a/lib/yelp/client.rb
+++ b/lib/yelp/client.rb
@@ -40,7 +40,7 @@ module Yelp
     #     config.token_secret = 'jkl'
     #   end
     def configure
-      raise AlreadyConfigured unless @configuration.nil?
+      raise Error::AlreadyConfigured unless @configuration.nil?
 
       @configuration = Configuration.new
       yield(@configuration)
@@ -51,7 +51,7 @@ module Yelp
     def check_api_keys
       if configuration.nil? || !configuration.valid?
         @configuration = nil
-        raise MissingAPIKeys
+        raise Error::MissingAPIKeys
       else
         # Freeze the configuration so it cannot be modified once the gem is
         # configured.  This prevents the configuration changing while the gem

--- a/lib/yelp/endpoint/search.rb
+++ b/lib/yelp/endpoint/search.rb
@@ -83,7 +83,8 @@ module Yelp
       #
       #   response = client.search(bounding_box, params)
       def search_by_bounding_box(bounding_box, params = {}, locale = {})
-        raise BoundingBoxNotComplete if BOUNDING_BOX.any? { |corner| bounding_box[corner].nil? }
+        raise Error::BoundingBoxNotComplete if BOUNDING_BOX.any? { |corner|
+          bounding_box[corner].nil? }
 
         options = { bounds: build_bounding_box(bounding_box) }
         options.merge!(params)
@@ -128,7 +129,8 @@ module Yelp
       #
       #   response = client.search(coordinates, params)
       def search_by_coordinates(coordinates, params = {}, locale = {})
-        raise MissingLatLng if coordinates[:latitude].nil? || coordinates[:longitude].nil?
+        raise Error::MissingLatLng if coordinates[:latitude].nil? ||
+            coordinates[:longitude].nil?
 
         options = { ll: build_coordinates_string(coordinates) }
         options.merge!(params)

--- a/lib/yelp/error.rb
+++ b/lib/yelp/error.rb
@@ -1,55 +1,57 @@
 module Yelp
-  class Error < StandardError
-    def self.check_for_error(data)
+  module Error
+    def self.check_for_error(request)
       # Check if the status is in the range of non-error status codes
-      return if (200..399).include?(data.status)
+      return if (200..399).include?(request.status)
 
-      body = JSON.parse(data.body)
+      body = JSON.parse(request.body)
       @error_classes ||= Hash.new do |hash, key|
         class_name = key.split('_').map(&:capitalize).join('').gsub('Oauth', 'OAuth')
-        hash[key] = Yelp.const_get(class_name)
+        hash[key] = Yelp::Error.const_get(class_name)
       end
 
       klass = @error_classes[body['error']['id']]
       raise klass.new(body['error']['text'])
     end
-  end
 
-  class AlreadyConfigured < Error
-    def initialize(msg = 'Gem cannot be reconfigured.  Initialize a new ' +
-        'instance of Yelp::Client.')
-      super
+    class Base < StandardError; end
+
+    class AlreadyConfigured < Base
+      def initialize(msg = 'Gem cannot be reconfigured.  Initialize a new ' +
+          'instance of Yelp::Client.')
+        super
+      end
     end
-  end
 
-  class MissingAPIKeys < Error
-    def initialize(msg = "You're missing an API key")
-      super
+    class MissingAPIKeys < Base
+      def initialize(msg = "You're missing an API key")
+        super
+      end
     end
-  end
 
-  class MissingLatLng < Error
-    def initialize(msg = 'Missing required latitude or longitude parameters')
-      super
+    class MissingLatLng < Base
+      def initialize(msg = 'Missing required latitude or longitude parameters')
+        super
+      end
     end
-  end
 
-  class BoundingBoxNotComplete < Error
-    def initialize(msg = 'Missing required values for bounding box')
-      super
+    class BoundingBoxNotComplete < Base
+      def initialize(msg = 'Missing required values for bounding box')
+        super
+      end
     end
-  end
 
-  class InternalError           < Error; end
-  class ExceededRequests        < Error; end
-  class MissingParameter        < Error; end
-  class InvalidParameter        < Error; end
-  class InvalidSignature        < Error; end
-  class InvalidOAuthCredentials < Error; end
-  class InvalidOAuthUser        < Error; end
-  class AccountUnconfirmed      < Error; end
-  class UnavailableForLocation  < Error; end
-  class AreaTooLarge            < Error; end
-  class MultipleLocations       < Error; end
-  class BusinessUnavailable     < Error; end
+    class InternalError           < Base; end
+    class ExceededRequests        < Base; end
+    class MissingParameter        < Base; end
+    class InvalidParameter        < Base; end
+    class InvalidSignature        < Base; end
+    class InvalidOAuthCredentials < Base; end
+    class InvalidOAuthUser        < Base; end
+    class AccountUnconfirmed      < Base; end
+    class UnavailableForLocation  < Base; end
+    class AreaTooLarge            < Base; end
+    class MultipleLocations       < Base; end
+    class BusinessUnavailable     < Base; end
+  end
 end

--- a/spec/support/request_error.rb
+++ b/spec/support/request_error.rb
@@ -5,7 +5,7 @@ shared_examples 'a request error' do
 
     it 'should raise an error' do
       client.stub_chain(:connection, :get).and_return(bad_response)
-      expect { request }.to raise_error(Yelp::InternalError)
+      expect { request }.to raise_error(Yelp::Error::InternalError)
     end
   end
 end

--- a/spec/yelp/endpoint/search_spec.rb
+++ b/spec/yelp/endpoint/search_spec.rb
@@ -57,11 +57,11 @@ describe Yelp::Endpoint::Search do
   describe 'errors' do
     context 'search' do
       it 'raises when #search_by_coordinates params are empty' do
-        expect { client.search_by_coordinates({}, params) }.to raise_error(Yelp::MissingLatLng)
+        expect { client.search_by_coordinates({}, params) }.to raise_error(Yelp::Error::MissingLatLng)
       end
 
       it 'raises when #search_by_bounding_box params are empty' do
-        expect { client.search_by_bounding_box({}, params) }.to raise_error(Yelp::BoundingBoxNotComplete)
+        expect { client.search_by_bounding_box({}, params) }.to raise_error(Yelp::Error::BoundingBoxNotComplete)
       end
     end
 

--- a/spec/yelp/error_spec.rb
+++ b/spec/yelp/error_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'yelp'
 
 describe Yelp::Error do
   context '#from_request' do
@@ -16,7 +15,7 @@ describe Yelp::Error do
     it 'should raise an internal error' do
       expect {
         Yelp::Error.check_for_error(bad_response)
-      }.to raise_error(Yelp::InternalError, 'error message')
+      }.to raise_error(Yelp::Error::InternalError, 'error message')
     end
   end
 end


### PR DESCRIPTION
I renamed the previous error base class to Error::Base, which I think brings it a little more inline with other gems.
