### PR TITLE
Fix BurstStruct's respond_to? for string keys.

### DIFF
--- a/lib/yelp/burst_struct.rb
+++ b/lib/yelp/burst_struct.rb
@@ -15,7 +15,7 @@ module BurstStruct
     end
 
     def respond_to?(method_name, include_private = false)
-      @hash.keys.include?(method_name) || super
+      has_key?(method_name) || super
     end
 
     def self.convert_array(array)
@@ -33,6 +33,10 @@ module BurstStruct
 
     def to_json(options = {})
       JSON.generate(@hash)
+    end
+
+    def has_key?(method_name)
+      !find_key(method_name).nil?
     end
 
     private

--- a/spec/yelp/burst_struct_spec.rb
+++ b/spec/yelp/burst_struct_spec.rb
@@ -8,12 +8,20 @@ describe BurstStruct::Burst do
       it 'should return' do
         expect(struct.foo).to eql 'bar'
       end
+
+      it { should have_key(:foo) }
+      it { should have_key('foo') }
+
+      it { should respond_to(:foo) }
     end
 
     context 'when a key does not exist' do
       it 'should not respond to it' do
         expect(struct.respond_to? :super_foo).to eql false
       end
+
+      it { should_not have_key(:super_foo) }
+      it { should_not have_key('super_foo') }
     end
   end
 
@@ -119,6 +127,21 @@ describe BurstStruct::Burst do
 
     it 'should deserialize to the same json' do
       expect(struct.to_json).to eql hash.to_json
+    end
+  end
+
+  context 'struct with string keys' do
+    subject(:struct) { BurstStruct::Burst.new('foo' => 'bar') }
+
+    context 'when a key exists' do
+      it 'should return' do
+        expect(struct.foo).to eql 'bar'
+      end
+
+      it { should have_key(:foo) }
+      it { should have_key('foo') }
+
+      it { should respond_to(:foo) }
     end
   end
 end


### PR DESCRIPTION
The custom struct implementation handles string/symbol keys correctly in
method_missing, but not in respond_to?. This change reuses the (already
factored out) code used by method_missing to implement a has_key?
method, and uses that method in respond_to?.
