### PR TITLE
Restrict simple oauth version as the newest release raises an exception due to unexpected tokens

### DIFF
--- a/yelp.gemspec
+++ b/yelp.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'faraday', '~> 0.8', '>= 0.8.0'
   spec.add_runtime_dependency 'faraday_middleware', '~> 0.8', '>= 0.8.0'
-  spec.add_runtime_dependency 'simple_oauth', '~> 0.2', '>= 0.2.0'
+  spec.add_runtime_dependency 'simple_oauth', '~> 0.2', '>= 0.2.0', '< 0.3.0'
 end


### PR DESCRIPTION
The newest version of simple_oauth raises an exception when it receives unexpected tokens. Restrict to a version that does not do this.

For more context see issue #21 
