### PR TITLE
Bump simple-oauth to 0.3.1 or higher

### DIFF
--- a/yelp.gemspec
+++ b/yelp.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'faraday', '~> 0.8', '>= 0.8.0'
   spec.add_runtime_dependency 'faraday_middleware', '~> 0.8', '>= 0.8.0'
-  spec.add_runtime_dependency 'simple_oauth', '~> 0.2', '>= 0.2.0', '< 0.3.0'
+  spec.add_runtime_dependency 'simple_oauth', '~> 0.3.1'
 end


### PR DESCRIPTION
In commit ee8d86f, the version was locked to pre-0.3.0 as an exception was raised in simple_oauth version 0.3.0. This exception was fixed in https://github.com/laserlemon/simple_oauth/pull/20 and released in a patch update 0.3.1.

I've run all the tests and included in my application to confirm that the exceptions found in 0.3.0 are no longer present in 0.3.1.

Let me know if there's anything else I can do to help here.