### PR TITLE
Correct the response type in the docs

### DIFF
--- a/lib/yelp/endpoint/business.rb
+++ b/lib/yelp/endpoint/business.rb
@@ -14,7 +14,7 @@ module Yelp
       # Make a request to the business endpoint on the API
       #
       # @param id [String] the business id
-      # @return [BurstStruct] the parsed response object from the API
+      # @return [Response::Business] the parsed response object from the API
       #
       # @example Get business
       #   business = client.business('yelp-san-francisco')

--- a/lib/yelp/endpoint/phone_search.rb
+++ b/lib/yelp/endpoint/phone_search.rb
@@ -14,7 +14,7 @@ module Yelp
       # Make a request to the business endpoint on the API
       #
       # @param phone_number [String] the phone number
-      # @return [BurstStruct::Burst] a parsed object of the response. For a complete
+      # @return [Response::PhoneSearch] a parsed object of the response. For a complete
       #   sample response visit:
       #   http://www.yelp.com/developers/documentation/v2/phone_search#sampleResponse
       #

--- a/lib/yelp/endpoint/search.rb
+++ b/lib/yelp/endpoint/search.rb
@@ -23,7 +23,7 @@ module Yelp
       #   http://www.yelp.com/developers/documentation/v2/search_api#searchGP
       # @param locale [Hash] a hash that corresponds to locale on the API:
       #   http://www.yelp.com/developers/documentation/v2/search_api#lParam
-      # @return [BurstStruct::Burst] a parsed object of the response. For a complete
+      # @return [Response::Search] a parsed object of the response. For a complete
       #   list of possible response values visit:
       #   http://www.yelp.com/developers/documentation/v2/search_api#rValue
       #
@@ -59,7 +59,7 @@ module Yelp
       #   http://www.yelp.com/developers/documentation/v2/search_api#searchGP
       # @param locale [Hash] a hash that corresponds to locale on the API:
       #   http://www.yelp.com/developers/documentation/v2/search_api#lParam
-      # @return [BurstStruct::Burst] a parsed object of the response. For a complete
+      # @return [Response::Search] a parsed object of the response. For a complete
       #   list of possible response values visit:
       #   http://www.yelp.com/developers/documentation/v2/search_api#rValue
       #
@@ -105,7 +105,7 @@ module Yelp
       #   http://www.yelp.com/developers/documentation/v2/search_api#searchGP
       # @param locale [Hash] a hash that corresponds to locale on the API:
       #   http://www.yelp.com/developers/documentation/v2/search_api#lParam
-      # @return [BurstStruct::Burst] a parsed object of the response. For a complete
+      # @return [Response::Search] a parsed object of the response. For a complete
       #   list of possible response values visit:
       #   http://www.yelp.com/developers/documentation/v2/search_api#rValue
       #


### PR DESCRIPTION
I realized I didn't update the docs for the endpoints when I killed the `BurstStruct`