### PR TITLE
Revert "Missing img_url attribute reader methods on business response model"

### DIFF
--- a/lib/yelp/responses/models/business.rb
+++ b/lib/yelp/responses/models/business.rb
@@ -10,8 +10,7 @@ module Yelp
       class Business < Response::Base
         attr_reader :categories, :deals, :display_phone, :distance, :eat24_url, :gift_certificates, :id, :image_url,
                     :is_claimed, :is_closed, :location, :menu_provider, :menu_date_updated, :mobile_url, :name, :phone,
-                    :rating, :reviews, :reservation_url, :review_count, :snippet_image_url, :snippet_text, :url,
-                    :rating_img_url, :rating_img_url_large, :rating_img_url_small
+                    :rating, :reviews, :reservation_url, :review_count, :snippet_image_url, :snippet_text, :url
 
         def initialize(json)
           super(json)


### PR DESCRIPTION
Reverts Yelp/yelp-ruby#39

I misunderstood the issue, we have a rating object that parses the url, the problem is that it's not consistently named from the API. I'll create a separate PR to fix that