### PR TITLE
Add a class to handle what the API returns sometimes

### DIFF
--- a/lib/yelp/error.rb
+++ b/lib/yelp/error.rb
@@ -84,6 +84,7 @@ module Yelp
 
     class InternalError           < Base; end
     class ExceededRequests        < Base; end
+    class ExceededReqs            < Base; end
     class MissingParameter        < Base; end
     class InvalidSignature        < Base; end
     class InvalidOAuthCredentials < Base; end


### PR DESCRIPTION
We've found that at times the API will return EXceededReqs, not ExceededRequests.  This adds that class so we don't get undefined errors.