### PR TITLE
Add API error description to error message.

### DIFF
--- a/lib/yelp/error.rb
+++ b/lib/yelp/error.rb
@@ -83,7 +83,8 @@ module Yelp
         unless error.nil?
           @text = error['text']
           @field = error['field']
-          msg = msg + ': ' + @field
+          description = error.has_key?('description') ? '. Description: ' + error['description'] : ''
+          msg = msg + ': ' + @field + description
         end
         super(msg,error)
       end

--- a/spec/yelp/error_spec.rb
+++ b/spec/yelp/error_spec.rb
@@ -40,5 +40,19 @@ describe Yelp::Error do
       end        
     end
 
+    context 'when the API returns the error description' do
+      let(:response_body) { '{"error": {"text": "One or more parameters are invalid in request", "id": "INVALID_PARAMETER", "field": "limit", "description": "Limit maximum is 20"}}' }
+
+      it 'should expose more details about the invalid parameter' do
+        begin
+          Yelp::Error.check_for_error(bad_response)
+        rescue Yelp::Error::InvalidParameter => e
+          # verifies that StandardError message attribute is available
+          expect(e.message).to eq('One or more parameters are invalid in request: limit. Description: Limit maximum is 20')
+          expect(e.field).to eq('limit')
+
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
First of all, thanks for publishing this gem. It's great!

I paying around with the Yelp API last night and ran into an issue with the `limit` param and had to debugged internally understand that my problem was the value I had assigned to it and not its presence.  

In this pull request I included a test that illustrates that and conditionally adds the `description`key that is returned from the API to the exception error message. 