### PR TITLE
Improve error message

### DIFF
--- a/lib/yelp/error.rb
+++ b/lib/yelp/error.rb
@@ -83,7 +83,8 @@ module Yelp
         unless error.nil?
           @text = error['text']
           @field = error['field']
-          msg = msg + ': ' + @field
+          description = error.has_key?('description') ? '. Description: ' + error['description'] : ''
+          msg = msg + ': ' + @field + description
         end
         super(msg,error)
       end

--- a/lib/yelp/error.rb
+++ b/lib/yelp/error.rb
@@ -83,8 +83,8 @@ module Yelp
         unless error.nil?
           @text = error['text']
           @field = error['field']
-          description = error.has_key?('description') ? '. Description: ' + error['description'] : ''
-          msg = msg + ': ' + @field + description
+          msg += ": #{@field}"
+          msg += ". Description: #{error['description']}" if error.has_key?('description')
         end
         super(msg,error)
       end

--- a/spec/yelp/error_spec.rb
+++ b/spec/yelp/error_spec.rb
@@ -30,14 +30,12 @@ describe Yelp::Error do
     end
 
     it 'should expose the field parameter' do 
-      begin
+      expect{
         Yelp::Error.check_for_error(bad_response)
-      rescue Yelp::Error::InvalidParameter => e 
-        # verifies that StandardError message attribute is available
-        expect(e.message).to eq('One or more parameters are invalid in request: oauth_token')
-        # verifies that we can get access to the specific field that was invalid
-        expect(e.field).to eq('oauth_token')
-      end        
+      }.to raise_error { |error|
+        error.message.should eq('One or more parameters are invalid in request: oauth_token')
+        error.field.should eq('oauth_token')
+      }
     end
 
     context 'when the API returns the error description' do

--- a/spec/yelp/error_spec.rb
+++ b/spec/yelp/error_spec.rb
@@ -44,14 +44,12 @@ describe Yelp::Error do
       let(:response_body) { '{"error": {"text": "One or more parameters are invalid in request", "id": "INVALID_PARAMETER", "field": "limit", "description": "Limit maximum is 20"}}' }
 
       it 'should expose more details about the invalid parameter' do
-        begin
+        expect {
           Yelp::Error.check_for_error(bad_response)
-        rescue Yelp::Error::InvalidParameter => e
-          # verifies that StandardError message attribute is available
-          expect(e.message).to eq('One or more parameters are invalid in request: limit. Description: Limit maximum is 20')
-          expect(e.field).to eq('limit')
-
-        end
+        }.to raise_error { |error|
+          error.message.should eq('One or more parameters are invalid in request: limit. Description: Limit maximum is 20')
+          error.field.should eq('limit')
+        }
       end
     end
   end

--- a/spec/yelp/error_spec.rb
+++ b/spec/yelp/error_spec.rb
@@ -40,5 +40,19 @@ describe Yelp::Error do
       end        
     end
 
+    context 'when the API returns the error description' do
+      let(:response_body) { '{"error": {"text": "One or more parameters are invalid in request", "id": "INVALID_PARAMETER", "field": "limit", "description": "Limit maximum is 20"}}' }
+
+      it 'should expose more details about the invalid parameter' do
+        begin
+          Yelp::Error.check_for_error(bad_response)
+        rescue Yelp::Error::InvalidParameter => e
+          # verifies that StandardError message attribute is available
+          expect(e.message).to eq('One or more parameters are invalid in request: limit. Description: Limit maximum is 20')
+          expect(e.field).to eq('limit')
+
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Including description of the error in the exception message. This is only included if provided back form the API.

I also standardized the error_spec to have all examples use raise_error.